### PR TITLE
chore: expose static resources explicitly

### DIFF
--- a/starter/src/main/java/com/example/starter/base/osgi/IconResource.java
+++ b/starter/src/main/java/com/example/starter/base/osgi/IconResource.java
@@ -1,0 +1,10 @@
+package com.example.starter.base.osgi;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardResource;
+
+@Component(service = IconResource.class)
+@HttpWhiteboardResource(pattern = "/static/icons/icon.png", prefix = "/static/icons/icon.png")
+public class IconResource {
+
+}

--- a/starter/src/main/java/com/example/starter/base/osgi/ImageResources.java
+++ b/starter/src/main/java/com/example/starter/base/osgi/ImageResources.java
@@ -1,0 +1,10 @@
+package com.example.starter.base.osgi;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardResource;
+
+@Component(service = ImageResources.class)
+@HttpWhiteboardResource(pattern = "/static/images/*", prefix = "/static/images")
+public class ImageResources {
+
+}


### PR DESCRIPTION
ServletContext resources are not available anymore via HTTP after
vaadin/osgi#50. So they should be exposed explicitly via resource
service